### PR TITLE
Install ca-certificates package to fix s2s SSL errors.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
         lua-zlib \
         lua5.1 \
         openssl \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Install and configure prosody


### PR DESCRIPTION
I got an error connecting via s2s to another host.

``` shell
incoming s2s stream foreign.domain->my.domain closed: Your server's certificate is invalid, expired, or not trusted by my.domain
```

It turned out, that the package ca-certificates was missing and prosody could not check the foreign SSL key. I logged into the container and installed ca-certificates and after a restart it's working as expected.
