### PR TITLE
Run with same UID as datadir owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,5 @@ RUN chmod 755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 80 443 5222 5269 5347 5280 5281
-USER prosody
 ENV __FLUSH_LOG yes
 CMD ["prosody", "-F"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+usermod -u "$(stat -c %u /var/lib/prosody/.)" prosody
+
 if [[ "$1" != "prosody" ]]; then
     exec prosodyctl "$@"
     exit 0;
@@ -10,4 +12,4 @@ if [ "$LOCAL" -a  "$PASSWORD" -a "$DOMAIN" ] ; then
     prosodyctl register "$LOCAL" "$DOMAIN" "$PASSWORD"
 fi
 
-exec "$@"
+runuser -u prosody -- "$@"


### PR DESCRIPTION
This should fix problems with owner/uid mismatch when an existing
prosody data directory is mounted into the container.

It does this by changing the uid of the `prosody` user (created by the `.deb`) to match that of `/var/lib/prosody`.

Replaces #39