### PR TITLE
Proper user&permission management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@
 # Based on ubuntu
 ################################################################################
 
-FROM debian:10
+FROM debian:stable-slim
 
-MAINTAINER Prosody Developers <developers@prosody.im>
+LABEL maintainer="Prosody Developers <developers@prosody.im>"
+
+RUN groupadd -g 1000 -r prosody && useradd -m -g prosody -u 1000 -r -s /bin/bash prosody
 
 # Install dependencies
 RUN apt-get update \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
 set -e
 
-usermod -u "$(stat -c %u /var/lib/prosody/.)" prosody
+CHOWN=${CHOWN:-\
+/etc/prosody \
+/var/lib/prosody \
+/var/run/prosody \
+/var/log/prosody \
+/usr/lib/prosody-modules \
+}
+
+if (( EUID == 0 )); then
+	for DIR in $CHOWN
+	do
+		find $DIR \! -user prosody -exec chown prosody '{}' +
+	done
+
+    setpriv --reuid=prosody --regid=prosody --init-groups "$BASH_SOURCE" "$@"
+fi
 
 if [[ "$1" != "prosody" ]]; then
     exec prosodyctl "$@"
@@ -12,4 +27,4 @@ if [ "$LOCAL" -a  "$PASSWORD" -a "$DOMAIN" ] ; then
     prosodyctl register "$LOCAL" "$DOMAIN" "$PASSWORD"
 fi
 
-runuser -u prosody -- "$@"
+exec "$@"


### PR DESCRIPTION
**Changelog:**
- changed user management based on [Best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user)

- it's better to set a consistent default uid/gid to avoid mismatches with future builds when upgrading
- it's necessary to create the group/user beforehand instead by installing packages (there was a different uid/gid set for the /var/run/prosody dir in the latest build)
- instead of gosu for root step-down we can use [setpriv](https://github.com/tianon/gosu#setpriv) on debian
- changed parent image to 'debian:stable-slim' - no need for a bloated image. no need to change the codename anymore when a new stable debian is released
- Maintainer is [deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) using `LABEL maintainer` instead

The _entrypoint.sh_ will automatically adjust permissions for imported files with another uid/gid.
If you want to run prosody as a specific user you can do this:

**docker-compose:**
```
tmpfs:
  - /run/prosody:uid=1000,gid=1000
user: 1000:1000
```

**docker run cli:**
`docker run --user="1000:1000" --tmpfs /run/prosody:uid=1000,gid=1000 ...`

But another user won't have access to _/run/prosody_
You either have to mount _/run/prosody_ with the users uid/gid like above or change the path of the _pidfile_ to one of your other mounted directories