### PR TITLE
Fix signal handling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,4 @@ if [ "$LOCAL" -a  "$PASSWORD" -a "$DOMAIN" ] ; then
     prosodyctl register "$LOCAL" "$DOMAIN" "$PASSWORD"
 fi
 
-runuser -u prosody -- "$@"
+exec runuser -u prosody -- "$@"


### PR DESCRIPTION
This patch add `exec` to replace the shell running the `entrypoint.sh`
script by Prosody executable.

This allows Prosody to catch and handle correctly signals, notably
SIGTERM and SIGINT. Without it, Docker can't stop correctly the
container, resulting in a 10 s delay before it kills it.