### PR TITLE
Fix mod_posix error if prosody user ID was altered

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 set -e
 
 data_dir_owner="$(stat -c %u "/var/lib/prosody/")"
@@ -14,7 +14,7 @@ if [[ "$1" != "prosody" ]]; then
     exit 0;
 fi
 
-if [ "$LOCAL" -a  "$PASSWORD" -a "$DOMAIN" ] ; then
+if [[ "$LOCAL" && "$PASSWORD" && "$DOMAIN" ]]; then
     prosodyctl register "$LOCAL" "$DOMAIN" "$PASSWORD"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -e
 
-usermod -u "$(stat -c %u /var/lib/prosody/.)" prosody
+data_dir_owner="$(stat -c %u "/var/lib/prosody/")"
+if [[ "$(id -u prosody)" != "$data_dir_owner" ]]; then
+    usermod -u "$data_dir_owner" prosody
+fi
+if [[ "$(stat -c %u /var/run/prosody/)" != "$data_dir_owner" ]]; then
+    chown "$data_dir_owner" /var/run/prosody/
+fi
 
 if [[ "$1" != "prosody" ]]; then
     exec prosodyctl "$@"


### PR DESCRIPTION
This fixes the following error that occurs if `/var/lib/prosody` is not owned by UID 101.

```
mod_posix           error  Couldn't write pidfile at /var/run/prosody/prosody.pid; /var/run/prosody/prosody.pid: Permission denied
```

Maybe #63 handles permissions better, but I didn't evaluate it properly. I only saw it introduces more significant changes and it's not merged yet, while my MR doesn't really change anything. It simply fixes what #62 missed.