### PR TITLE
Use tini as PID 1 inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         openssl \
         ca-certificates \
         ssl-cert \
+        tini \
     && rm -rf /var/lib/apt/lists/*
 
 # Install and configure prosody

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [[ "$(stat -c %u /var/run/prosody/)" != "$data_dir_owner" ]]; then
 fi
 
 if [[ "$1" != "prosody" ]]; then
-    exec prosodyctl "$@"
+    exec tini -- prosodyctl "$@"
     exit 0;
 fi
 
@@ -18,4 +18,4 @@ if [[ "$LOCAL" && "$PASSWORD" && "$DOMAIN" ]]; then
     prosodyctl register "$LOCAL" "$DOMAIN" "$PASSWORD"
 fi
 
-exec runuser -u prosody -- "$@"
+exec tini -- runuser -u prosody -- "$@"


### PR DESCRIPTION
tini [1] is a minimalistic PID 1 process. It correctly handles
the special jobs which PID 1 (or a reaper process in general)
needs to take care of in addition to correctly processing the
relevant signals.

Fixes #68.

   [1]: https://github.com/krallin/tini