### PR TITLE
Graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update \
         openssl \
         ca-certificates \
         ssl-cert \
-        tini \
     && rm -rf /var/lib/apt/lists/*
 
 # Install and configure prosody

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,4 @@ if [[ "$LOCAL" && "$PASSWORD" && "$DOMAIN" ]]; then
     prosodyctl register "$LOCAL" "$DOMAIN" "$PASSWORD"
 fi
 
-exec runuser -u prosody -- "$@"
+exec setpriv --reuid=prosody --regid=prosody --init-groups "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [[ "$(stat -c %u /var/run/prosody/)" != "$data_dir_owner" ]]; then
 fi
 
 if [[ "$1" != "prosody" ]]; then
-    exec tini -- prosodyctl "$@"
+    exec prosodyctl "$@"
     exit 0;
 fi
 
@@ -18,4 +18,4 @@ if [[ "$LOCAL" && "$PASSWORD" && "$DOMAIN" ]]; then
     prosodyctl register "$LOCAL" "$DOMAIN" "$PASSWORD"
 fi
 
-exec tini -- runuser -u prosody -- "$@"
+exec runuser -u prosody -- "$@"


### PR DESCRIPTION
We have a (currently still private, that might change) image based on prosody/prosody:0.11 and graceful shutdowan did not work, yet. There are few tickets now addressing that issue: #65, #68, #69.

The requirements are complex:

- prosody itself does not permit to run as uid 0 (root)
- prosody is not capable of dropping priviledges by itself
- prosodyctl requires to run as root
- entrypoint.sh handles both prosodyctl and prosody (which is actually quite convenient)

Hence the entrypoint.sh script itself must ensure running prosody as unpriviledged user, which was solved with the `runuser` tool in commit 95a9d24b76a7596afc6e456a65febf1f53a53249.

The pull request is about replacing runuser with setpriv as suggested by @maz3max in #68.

See commit messages for detailed explanations.